### PR TITLE
feat: add message recall support (dogfooding result)

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -1,11 +1,14 @@
 package models
 
 import (
-	"gorm.io/gorm"
 	"sort"
 	"strconv"
 	"time"
+
+	"gorm.io/gorm"
 )
+
+const RecallTimeLimit = 2 * time.Minute
 
 type Message struct {
 	gorm.Model
@@ -39,7 +42,7 @@ func SaveContent(value interface{}) Message {
 	return m
 }
 
-func GetLimitMsg(roomId string,offset int) []map[string]interface{} {
+func GetLimitMsg(roomId string, offset int) []map[string]interface{} {
 
 	var results []map[string]interface{}
 	ChatDB.Model(&Message{}).
@@ -52,16 +55,26 @@ func GetLimitMsg(roomId string,offset int) []map[string]interface{} {
 		Limit(100).
 		Scan(&results)
 
-	if offset == 0{
+	if offset == 0 {
 		sort.Slice(results, func(i, j int) bool {
 			return results[i]["id"].(uint32) < results[j]["id"].(uint32)
 		})
 	}
 
+	for i := range results {
+		createdAt, ok := results[i]["created_at"].(time.Time)
+		if ok {
+			isRecallable := time.Since(createdAt) < RecallTimeLimit
+			results[i]["is_recallable"] = isRecallable
+		} else {
+			results[i]["is_recallable"] = false
+		}
+	}
+
 	return results
 }
 
-func GetLimitPrivateMsg(uid, toUId string,offset int) []map[string]interface{} {
+func GetLimitPrivateMsg(uid, toUId string, offset int) []map[string]interface{} {
 
 	var results []map[string]interface{}
 	ChatDB.Model(&Message{}).
@@ -77,11 +90,30 @@ func GetLimitPrivateMsg(uid, toUId string,offset int) []map[string]interface{} {
 		Limit(100).
 		Scan(&results)
 
-	if offset == 0{
+	if offset == 0 {
 		sort.Slice(results, func(i, j int) bool {
 			return results[i]["id"].(uint32) < results[j]["id"].(uint32)
 		})
 	}
 
 	return results
+}
+
+func RecallMessage(msgId uint, userId int) bool {
+	var msg Message
+	err := ChatDB.First(&msg, msgId).Error
+	if err != nil {
+		return false
+	}
+
+	if msg.UserId != userId {
+		return false
+	}
+
+	if time.Since(msg.CreatedAt) > RecallTimeLimit {
+		return false
+	}
+
+	err = ChatDB.Delete(&msg).Error
+	return err == nil
 }

--- a/static/javascripts/Public.js
+++ b/static/javascripts/Public.js
@@ -109,7 +109,7 @@ function WebSocketConnect(userInfo,toUserInfo = null) {
 					if ( received_msg.data.uid != userInfo.uid && !isPrivateChat())
 					{
 						chat_info.html(chat_info.html() +
-							'<li class="left"><img src="/static/images/user/' +
+							'<li class="left" data-msg-id="' + received_msg.data.msg_id + '"><img src="/static/images/user/' +
 							received_msg.data.avatar_id +
 							'.png" alt=""><b>' +
 							received_msg.data.username +
@@ -118,6 +118,25 @@ function WebSocketConnect(userInfo,toUserInfo = null) {
 							'</i><div class="aaa">' +
 							received_msg.data.content +
 							'</div></li>');
+					}
+					if ( received_msg.data.uid == userInfo.uid && !isPrivateChat())
+					{
+						let lastLi = chat_info.find('li.right:last');
+						if (lastLi.length > 0) {
+							lastLi.addClass('recallable-message');
+							lastLi.attr('data-msg-id', received_msg.data.msg_id);
+							let recallBtn = lastLi.find('.recall-btn');
+							recallBtn.show();
+							lastLi.data('send-time', Date.now());
+							let sendTime = Date.now();
+							let checkInterval = setInterval(function() {
+								if (Date.now() - sendTime > 2 * 60 * 1000) {
+									recallBtn.hide();
+									lastLi.removeClass('recallable-message');
+									clearInterval(checkInterval);
+								}
+							}, 1000);
+						}
 					}
 					break;
 				case -1:
@@ -160,6 +179,22 @@ function WebSocketConnect(userInfo,toUserInfo = null) {
 					if (!isPrivateChat())
 					{
 						layer.msg(received_msg.data.username+'：'+ received_msg.data.content);
+					}
+					break;
+				case 6:
+					console.log('收到撤回消息响应:', received_msg);
+					if (received_msg.data.content === "success") {
+						let msgId = received_msg.data.msg_id;
+						console.log('要撤回的消息ID:', msgId);
+						let targetLi = chat_info.find('li[data-msg-id="' + msgId + '"]');
+						console.log('找到的目标元素:', targetLi);
+						if (targetLi.length > 0) {
+							targetLi.removeClass('right left recallable-message');
+							targetLi.addClass('systeminfo');
+							targetLi.html('<span>【' + received_msg.data.username + '】 撤回了一条消息</span>');
+						}
+					} else {
+						layer.msg("撤回失败，可能已超过2分钟或无权撤回");
 					}
 					break;
 				default:
@@ -364,6 +399,44 @@ $(document).ready(function(){
 
 	});
 
+	// 鼠标悬停显示撤回按钮
+	$(document).on('mouseenter', '.recallable-message', function() {
+		$(this).find('.recall-btn').show();
+	});
+	$(document).on('mouseleave', '.recallable-message', function() {
+		$(this).find('.recall-btn').hide();
+	});
+
+	// 撤回消息点击事件
+	$(document).on('click', '.recall-btn', function(e) {
+		e.stopPropagation();
+		let li = $(this).closest('li');
+		let msgId = li.attr('data-msg-id');
+		console.log('点击撤回按钮，msgId:', msgId);
+		
+		if (!msgId) {
+			return;
+		}
+		
+		if (msgId.startsWith('temp_')) {
+			layer.msg('消息正在同步中，请稍后再试');
+			return;
+		}
+		
+		let send_data = JSON.stringify({
+			"status": 6,
+			"data": {
+				"uid": $('.room').attr('data-uid').toString(),
+				"username": $('.room').attr('data-username'),
+				"avatar_id": $('.room').attr('data-avatar_id'),
+				"room_id": $('.room').attr('data-room_id'),
+				"msg_id": parseInt(msgId),
+			}
+		});
+		console.log('发送撤回消息:', send_data);
+		ws.send(send_data);
+	});
+
 	// 发送消息
 	
 	//$('.text input').focus();
@@ -497,7 +570,8 @@ $(document).ready(function(){
 
 			let myDate = new Date();
 			let time = myDate.toLocaleDateString() + myDate.toLocaleTimeString()
-			$('.main .chat_info').html($('.main .chat_info').html() + '<li class="right"><img src="/static/images/user/' + userPortrait + '.png" alt=""><b>' + userName + '</b><i>'+ time +'</i><div class="">' + message  +'</div></li>');
+			let msgId = 'temp_' + Date.now();
+			$('.main .chat_info').html($('.main .chat_info').html() + '<li class="right recallable-message" data-msg-id="' + msgId + '"><img src="/static/images/user/' + userPortrait + '.png" alt=""><b>' + userName + '</b><i>'+ time +'</i><div class="msg-content">' + message  +'</div><div class="recall-btn" style="display:none; cursor:pointer; color:#409EFF; font-size:12px; margin-top:5px; text-decoration: underline;">撤回</div></li>');
 		}
 	}
 	$('.text input').keypress(function(e) {

--- a/views/room.html
+++ b/views/room.html
@@ -65,22 +65,29 @@
 
                     {{if eq $uid .user_id}}
 
-                        <li class="right">
+                        {{ if .is_recallable }}
+                        <li class="right recallable-message" data-msg-id="{{ .id }}">
+                        {{ else }}
+                        <li class="right" data-msg-id="{{ .id }}">
+                        {{ end }}
                             <img src="/static/images/user/{{ .avatar_id }}.png" alt="">
                             <b>{{ .username }}</b>
                             <i>{{ .created_at }}</i>
 
                             {{ if eq .image_url $nullSrl }}
 
-                            <div>{{ .content }}</div>
+                            <div class="msg-content">{{ .content }}</div>
                                 {{else}}
-                            <div><img class="load-img" data-src="{{ .image_url }}" src="https://cdn.jsdelivr.net/gh/hezhizheng/static-image-hosting@master/image-hosting/20210420094013_LVZYIITUUVRWREEE.jpg"/></div>
+                            <div class="msg-content"><img class="load-img" data-src="{{ .image_url }}" src="https://cdn.jsdelivr.net/gh/hezhizheng/static-image-hosting@master/image-hosting/20210420094013_LVZYIITUUVRWREEE.jpg"/></div>
                                 {{end}}
+                            {{ if .is_recallable }}
+                            <div class="recall-btn" style="display:none; cursor:pointer; color:#409EFF; font-size:12px; margin-top:5px; text-decoration: underline;">撤回</div>
+                            {{ end }}
                         </li>
 
                     {{else}}
 
-                        <li class="left">
+                        <li class="left" data-msg-id="{{ .id }}">
                             <img src="/static/images/user/{{ .avatar_id }}.png" alt="">
                             <b>{{ .username }}</b>
                             <i>{{ .created_at }}</i>
@@ -136,6 +143,31 @@
 <script>
 
     $(document).ready(function () {
+        // 对于已经有 recallable-message 类的历史消息，设置 2 分钟后隐藏
+        $('.chat_info li.recallable-message').each(function() {
+            let li = $(this);
+            let createdAt = li.find('i').text();
+            if (createdAt) {
+                try {
+                    let dateStr = createdAt.replace(/-/g, '/');
+                    let createdTime = new Date(dateStr).getTime();
+                    if (!isNaN(createdTime)) {
+                        let nowTime = Date.now();
+                        let timeDiff = nowTime - createdTime;
+                        let remainingTime = 2 * 60 * 1000 - timeDiff;
+                        if (remainingTime > 0) {
+                            setTimeout(function() {
+                                li.removeClass('recallable-message');
+                                li.find('.recall-btn').hide();
+                            }, remainingTime);
+                        }
+                    }
+                } catch(e) {
+                    console.log('处理时间失败', e);
+                }
+            }
+        });
+
         // WebSocketConnect
 
         let userInfo = {

--- a/ws/go_ws/serve.go
+++ b/ws/go_ws/serve.go
@@ -43,6 +43,7 @@ type msgData struct {
 	Count    int           `json:"count"`
 	List     []interface{} `json:"list"`
 	Time     int64         `json:"time"`
+	MsgId    uint          `json:"msg_id"`
 }
 
 // client & serve 的消息体
@@ -89,6 +90,7 @@ const msgTypeOffline = 2       // 离线
 const msgTypeSend = 3          // 消息发送
 const msgTypeGetOnlineUser = 4 // 获取用户列表
 const msgTypePrivateChat = 5   // 私聊
+const msgTypeRecall = 6        // 撤回消息
 
 const roomCount = 6 // 房间总数
 
@@ -275,6 +277,11 @@ func write(done <-chan struct{}) {
 					toC.(wsClients).Conn.WriteMessage(websocket.TextMessage, serveMsgStr)
 				}
 				<-chNotify
+			case msgTypeRecall:
+				notify(cl.Conn, string(serveMsgStr))
+				chNotify <- 1
+				cl.Conn.WriteMessage(websocket.TextMessage, serveMsgStr)
+				<-chNotify
 			}
 		case o := <-offline:
 			disconnect(o)
@@ -454,9 +461,10 @@ func formatServeMsgStr(status int, conn *websocket.Conn) ([]byte, msg) {
 		// 保存消息
 		intUid, _ := strconv.Atoi(uid)
 
+		var savedMsg models.Message
 		if imageUrl != "" {
 			// 存在图片
-			models.SaveContent(map[string]interface{}{
+			savedMsg = models.SaveContent(map[string]interface{}{
 				"user_id":    intUid,
 				"to_user_id": toUid,
 				"content":    data.Content,
@@ -464,20 +472,32 @@ func formatServeMsgStr(status int, conn *websocket.Conn) ([]byte, msg) {
 				"image_url":  imageUrl,
 			})
 		} else {
-			models.SaveContent(map[string]interface{}{
+			savedMsg = models.SaveContent(map[string]interface{}{
 				"user_id":    intUid,
 				"to_user_id": toUid,
 				"content":    data.Content,
 				"room_id":    data.RoomId,
 			})
 		}
-
+		data.MsgId = savedMsg.ID
 	}
 
 	if status == msgTypeGetOnlineUser {
 		ro := rooms[roomIdInt]
 		data.Count = len(ro)
 		data.List = ro
+	}
+
+	if status == msgTypeRecall {
+		data.AvatarId = avatarId
+		data.MsgId = clientMsg.Data.MsgId
+		intUid, _ := strconv.Atoi(uid)
+		success := models.RecallMessage(clientMsg.Data.MsgId, intUid)
+		if !success {
+			data.Content = "failed"
+		} else {
+			data.Content = "success"
+		}
 	}
 
 	jsonStrServeMsg := msg{


### PR DESCRIPTION
## Summary
- add backend and frontend changes for message recall support
- generated during dogfooding of Doubao Seed Code 2.0
- kept as reviewable evidence for the evaluation run

## Session
- Session ID: .2367719388755610:caaddb63c770152b5deb1745e0ad84cd_69da1a64c023ffbbf14fadb7.69da1c88c023ffbbf14fae3c.69da1c87a5d42e5065010aa1:Trae CN.T(4/11/2026, 6:03:52 PM)
- Interaction rounds: 4
- Model: Doubao Seed Code 2.0

## Evaluation summary
- Suggested overall satisfaction: 2/5
- Problem types: 代码 Bug, 指令遵循失败, 上下文丢失
- Fix cost: High

## Verified issues
- first delivery claimed the feature was complete, but there was no visible recall entry in the UI
- after follow-up prompts, history messages still showed recall buttons incorrectly after refresh
- some newly sent messages still used temporary msgId values starting with temp_, so recall could not complete
- final behavior only showed a syncing toast instead of actually removing or recalling the message

## Note
- this PR is for dogfooding traceability and review
- it is not a claim that the feature is production-ready or ready to merge
- evaluation note: /Users/alfwong/codes/ai-coding/dogfooding/Doubao Seed Code 2.0 - Go聊天室消息撤回功能评估.md