### PR TITLE
feat: add message recall support (dogfooding result, Kimi K2.5)

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -1,22 +1,24 @@
 package models
 
 import (
-	"gorm.io/gorm"
 	"sort"
 	"strconv"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type Message struct {
 	gorm.Model
-	ID        uint
-	UserId    int
-	ToUserId  int
-	RoomId    int
-	Content   string
-	ImageUrl  string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID         uint
+	UserId     int
+	ToUserId   int
+	RoomId     int
+	Content    string
+	ImageUrl   string
+	IsRecalled int `gorm:"default:0"` // 0: 未撤回, 1: 已撤回
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 func SaveContent(value interface{}) Message {
@@ -39,7 +41,33 @@ func SaveContent(value interface{}) Message {
 	return m
 }
 
-func GetLimitMsg(roomId string,offset int) []map[string]interface{} {
+// RecallMessage 撤回消息
+func RecallMessage(messageId int, userId int) error {
+	var m Message
+	result := ChatDB.First(&m, messageId)
+	if result.Error != nil {
+		return result.Error
+	}
+	// 只能撤回自己的消息
+	if m.UserId != userId {
+		return gorm.ErrRecordNotFound
+	}
+	// 检查是否在2分钟内
+	if time.Since(m.CreatedAt) > 2*time.Minute {
+		return gorm.ErrRecordNotFound
+	}
+	m.IsRecalled = 1
+	return ChatDB.Save(&m).Error
+}
+
+// GetMessageById 根据ID获取消息
+func GetMessageById(messageId int) (Message, error) {
+	var m Message
+	result := ChatDB.First(&m, messageId)
+	return m, result.Error
+}
+
+func GetLimitMsg(roomId string, offset int) []map[string]interface{} {
 
 	var results []map[string]interface{}
 	ChatDB.Model(&Message{}).
@@ -52,7 +80,7 @@ func GetLimitMsg(roomId string,offset int) []map[string]interface{} {
 		Limit(100).
 		Scan(&results)
 
-	if offset == 0{
+	if offset == 0 {
 		sort.Slice(results, func(i, j int) bool {
 			return results[i]["id"].(uint32) < results[j]["id"].(uint32)
 		})
@@ -61,7 +89,7 @@ func GetLimitMsg(roomId string,offset int) []map[string]interface{} {
 	return results
 }
 
-func GetLimitPrivateMsg(uid, toUId string,offset int) []map[string]interface{} {
+func GetLimitPrivateMsg(uid, toUId string, offset int) []map[string]interface{} {
 
 	var results []map[string]interface{}
 	ChatDB.Model(&Message{}).
@@ -77,7 +105,7 @@ func GetLimitPrivateMsg(uid, toUId string,offset int) []map[string]interface{} {
 		Limit(100).
 		Scan(&results)
 
-	if offset == 0{
+	if offset == 0 {
 		sort.Slice(results, func(i, j int) bool {
 			return results[i]["id"].(uint32) < results[j]["id"].(uint32)
 		})

--- a/sql/go_gin_chat.sql
+++ b/sql/go_gin_chat.sql
@@ -14,6 +14,7 @@ CREATE TABLE `messages`  (
   `to_user_id` int(11) NULL DEFAULT 0 COMMENT '私聊用户ID',
   `content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT '聊天内容',
   `image_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT '' COMMENT '图片URL',
+  `is_recalled` int(11) NULL DEFAULT 0 COMMENT '是否撤回: 0-未撤回, 1-已撤回',
   `created_at` datetime(0) NULL DEFAULT NULL,
   `updated_at` datetime(0) NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP(0),
   `deleted_at` datetime(0) NULL DEFAULT NULL,

--- a/static/javascripts/Public.js
+++ b/static/javascripts/Public.js
@@ -106,20 +106,45 @@ function WebSocketConnect(userInfo,toUserInfo = null) {
 						'</span></li>');
 					break;
 				case 3:
-					if ( received_msg.data.uid != userInfo.uid && !isPrivateChat())
-					{
-						chat_info.html(chat_info.html() +
-							'<li class="left"><img src="/static/images/user/' +
-							received_msg.data.avatar_id +
-							'.png" alt=""><b>' +
-							received_msg.data.username +
-							'</b><i>' +
-							time +
-							'</i><div class="aaa">' +
-							received_msg.data.content +
-							'</div></li>');
-					}
-					break;
+			if ( received_msg.data.uid != userInfo.uid && !isPrivateChat())
+			{
+				chat_info.html(chat_info.html() +
+					'<li class="left" data-message-id="' + received_msg.data.message_id + '" data-user-id="' + received_msg.data.uid + '"><img src="/static/images/user/' +
+					received_msg.data.avatar_id +
+					'.png" alt=""><b>' +
+					received_msg.data.username +
+					'</b><i>' +
+					time +
+					'</i><div class="aaa">' +
+					received_msg.data.content +
+					'</div></li>');
+			} else if ( received_msg.data.uid == userInfo.uid && !isPrivateChat() ) {
+				// 自己发送的消息，添加消息ID到DOM
+				var lastLi = chat_info.find('li.right').last();
+				lastLi.attr('data-message-id', received_msg.data.message_id);
+				lastLi.attr('data-user-id', received_msg.data.uid);
+				// 添加撤回按钮（如果还没有的话）
+				if (lastLi.find('.recall-btn').length === 0) {
+					lastLi.append('<span class="recall-btn" style="display:none;cursor:pointer;color:#999;font-size:12px;margin-top:5px;">撤回</span>');
+				}
+			}
+			break;
+			case 6:
+			// 撤回消息通知
+			var messageId = received_msg.data.message_id;
+			var msgLi = chat_info.find('li[data-message-id="' + messageId + '"]');
+			if (msgLi.length > 0) {
+				// 移除消息内容（包括文本和图片）
+				msgLi.find('div:not(.recalled-msg)').remove();
+				msgLi.find('img.load-img').remove();
+				// 移除撤回按钮
+				msgLi.find('.recall-btn').remove();
+				// 添加已撤回提示（如果不存在）
+				if (msgLi.find('.recalled-msg').length === 0) {
+					msgLi.append('<div class="recalled-msg">消息已撤回</div>');
+				}
+			}
+			break;
 				case -1:
 					ws.close() // 主动close掉
 					isServeClose = 1
@@ -497,7 +522,7 @@ $(document).ready(function(){
 
 			let myDate = new Date();
 			let time = myDate.toLocaleDateString() + myDate.toLocaleTimeString()
-			$('.main .chat_info').html($('.main .chat_info').html() + '<li class="right"><img src="/static/images/user/' + userPortrait + '.png" alt=""><b>' + userName + '</b><i>'+ time +'</i><div class="">' + message  +'</div></li>');
+			$('.main .chat_info').html($('.main .chat_info').html() + '<li class="right" data-send-time="' + Date.now() + '"><img src="/static/images/user/' + userPortrait + '.png" alt=""><b>' + userName + '</b><i>'+ time +'</i><div class="">' + message  +'</div><span class="recall-btn" style="display:none;cursor:pointer;color:#999;font-size:12px;margin-top:5px;">撤回</span></li>');
 		}
 	}
 	$('.text input').keypress(function(e) {
@@ -534,6 +559,74 @@ function isPrivateChat()
 {
 	return window.location.href.search('private-chat') > 0
 }
+
+// 显示撤回按钮（2分钟内有效）
+function showRecallBtn(liElement) {
+	if (!liElement || liElement.length === 0) return;
+	
+	var recallBtn = liElement.find('.recall-btn');
+	if (recallBtn.length === 0) return;
+	
+	// 显示撤回按钮
+	recallBtn.show();
+	
+	// 2分钟后隐藏撤回按钮
+	setTimeout(function() {
+		recallBtn.hide();
+	}, 2 * 60 * 1000);
+}
+
+// 发送撤回消息请求
+function sendRecallMessage(messageId) {
+	let send_data = JSON.stringify({
+		"status": 6,
+		"data": {
+			"uid": $('.room').attr('data-uid').toString(),
+			"username": $('.room').attr('data-username'),
+			"avatar_id": $('.room').attr('data-avatar_id'),
+			"room_id": $('.room').attr('data-room_id'),
+			"message_id": messageId,
+			"content": "",
+			"image_url" : "",
+			"to_uid" : "0",
+		}
+	});
+	ws.send(send_data);
+}
+
+// 页面加载完成后绑定撤回按钮点击事件
+$(document).on('click', '.recall-btn', function(e) {
+	e.stopPropagation();
+	var liElement = $(this).closest('li');
+	var messageId = liElement.attr('data-message-id');
+	if (messageId) {
+		sendRecallMessage(parseInt(messageId));
+	}
+});
+
+// 鼠标悬停显示撤回按钮（2分钟内的消息）
+$(document).on('mouseenter', 'li.right', function() {
+	var sendTime = $(this).attr('data-send-time');
+	var messageId = $(this).attr('data-message-id');
+	if (!sendTime && messageId) {
+		// 从历史消息加载的，使用 created_at
+		var createdAt = $(this).attr('data-created-at');
+		if (createdAt) {
+			var createdTime = new Date(createdAt).getTime();
+			if (Date.now() - createdTime < 2 * 60 * 1000) {
+				$(this).find('.recall-btn').show();
+			}
+		}
+	} else if (sendTime) {
+		if (Date.now() - parseInt(sendTime) < 2 * 60 * 1000) {
+			$(this).find('.recall-btn').show();
+		}
+	}
+});
+
+$(document).on('mouseleave', 'li.right', function() {
+	$(this).find('.recall-btn').hide();
+});
 
 function toLow() {
 	$('.scrollbar-macosx.scroll-content.scroll-scrolly_visible').animate({

--- a/views/room.html
+++ b/views/room.html
@@ -65,30 +65,37 @@
 
                     {{if eq $uid .user_id}}
 
-                        <li class="right">
+                        <li class="right" data-message-id="{{ .id }}" data-user-id="{{ .user_id }}" data-created-at="{{ .created_at }}">
                             <img src="/static/images/user/{{ .avatar_id }}.png" alt="">
                             <b>{{ .username }}</b>
                             <i>{{ .created_at }}</i>
 
-                            {{ if eq .image_url $nullSrl }}
-
-                            <div>{{ .content }}</div>
+                            {{ if eq .is_recalled 1 }}
+                                <div class="recalled-msg">消息已撤回</div>
+                            {{ else }}
+                                {{ if eq .image_url $nullSrl }}
+                                <div>{{ .content }}</div>
                                 {{else}}
-                            <div><img class="load-img" data-src="{{ .image_url }}" src="https://cdn.jsdelivr.net/gh/hezhizheng/static-image-hosting@master/image-hosting/20210420094013_LVZYIITUUVRWREEE.jpg"/></div>
+                                <div><img class="load-img" data-src="{{ .image_url }}" src="https://cdn.jsdelivr.net/gh/hezhizheng/static-image-hosting@master/image-hosting/20210420094013_LVZYIITUUVRWREEE.jpg"/></div>
                                 {{end}}
+                                <span class="recall-btn" style="display:none;cursor:pointer;color:#999;font-size:12px;margin-top:5px;">撤回</span>
+                            {{end}}
                         </li>
 
                     {{else}}
 
-                        <li class="left">
+                        <li class="left" data-message-id="{{ .id }}" data-user-id="{{ .user_id }}" data-created-at="{{ .created_at }}">
                             <img src="/static/images/user/{{ .avatar_id }}.png" alt="">
                             <b>{{ .username }}</b>
                             <i>{{ .created_at }}</i>
-                            {{ if eq .image_url $nullSrl }}
-
+                            {{ if eq .is_recalled 1 }}
+                                <div class="recalled-msg">消息已撤回</div>
+                            {{ else }}
+                                {{ if eq .image_url $nullSrl }}
                                 <div>{{ .content }}</div>
-                            {{else}}
+                                {{else}}
                                 <div><img class="load-img" data-src="{{ .image_url }}" src="https://cdn.jsdelivr.net/gh/hezhizheng/static-image-hosting@master/image-hosting/20210420094013_LVZYIITUUVRWREEE.jpg"/></div>
+                                {{end}}
                             {{end}}
                         </li>
 

--- a/ws/go_ws/serve.go
+++ b/ws/go_ws/serve.go
@@ -33,16 +33,18 @@ type wsClients struct {
 }
 
 type msgData struct {
-	Uid      string        `json:"uid"`
-	Username string        `json:"username"`
-	AvatarId string        `json:"avatar_id"`
-	ToUid    string        `json:"to_uid"`
-	Content  string        `json:"content"`
-	ImageUrl string        `json:"image_url"`
-	RoomId   string        `json:"room_id"`
-	Count    int           `json:"count"`
-	List     []interface{} `json:"list"`
-	Time     int64         `json:"time"`
+	Uid        string        `json:"uid"`
+	Username   string        `json:"username"`
+	AvatarId   string        `json:"avatar_id"`
+	ToUid      string        `json:"to_uid"`
+	Content    string        `json:"content"`
+	ImageUrl   string        `json:"image_url"`
+	RoomId     string        `json:"room_id"`
+	Count      int           `json:"count"`
+	List       []interface{} `json:"list"`
+	Time       int64         `json:"time"`
+	MessageId  int           `json:"message_id"`
+	IsRecalled int           `json:"is_recalled"`
 }
 
 // client & serve 的消息体
@@ -89,6 +91,7 @@ const msgTypeOffline = 2       // 离线
 const msgTypeSend = 3          // 消息发送
 const msgTypeGetOnlineUser = 4 // 获取用户列表
 const msgTypePrivateChat = 5   // 私聊
+const msgTypeRecall = 6        // 撤回消息
 
 const roomCount = 6 // 房间总数
 
@@ -275,6 +278,9 @@ func write(done <-chan struct{}) {
 					toC.(wsClients).Conn.WriteMessage(websocket.TextMessage, serveMsgStr)
 				}
 				<-chNotify
+			case msgTypeRecall:
+				// 撤回消息需要广播给所有用户
+				notify(cl.Conn, string(serveMsgStr))
 			}
 		case o := <-offline:
 			disconnect(o)
@@ -427,6 +433,7 @@ func formatServeMsgStr(status int, conn *websocket.Conn) ([]byte, msg) {
 	content := clientMsg.Data.Content
 	toUidStr := clientMsg.Data.ToUid
 	imageUrl := clientMsg.Data.ImageUrl
+	messageId := clientMsg.Data.MessageId
 	clientMsgLock.Unlock()
 
 	roomIdInt, _ := strconv.Atoi(roomId)
@@ -454,9 +461,10 @@ func formatServeMsgStr(status int, conn *websocket.Conn) ([]byte, msg) {
 		// 保存消息
 		intUid, _ := strconv.Atoi(uid)
 
+		var savedMsg models.Message
 		if imageUrl != "" {
 			// 存在图片
-			models.SaveContent(map[string]interface{}{
+			savedMsg = models.SaveContent(map[string]interface{}{
 				"user_id":    intUid,
 				"to_user_id": toUid,
 				"content":    data.Content,
@@ -464,20 +472,36 @@ func formatServeMsgStr(status int, conn *websocket.Conn) ([]byte, msg) {
 				"image_url":  imageUrl,
 			})
 		} else {
-			models.SaveContent(map[string]interface{}{
+			savedMsg = models.SaveContent(map[string]interface{}{
 				"user_id":    intUid,
 				"to_user_id": toUid,
 				"content":    data.Content,
 				"room_id":    data.RoomId,
 			})
 		}
-
+		// 返回消息ID给前端
+		data.MessageId = int(savedMsg.ID)
 	}
 
 	if status == msgTypeGetOnlineUser {
 		ro := rooms[roomIdInt]
 		data.Count = len(ro)
 		data.List = ro
+	}
+
+	if status == msgTypeRecall {
+		// 处理撤回消息
+		data.MessageId = messageId
+		intUid, _ := strconv.Atoi(uid)
+		err := models.RecallMessage(messageId, intUid)
+		if err != nil {
+			log.Println("撤回消息失败:", err)
+			// 撤回失败，返回错误状态
+			data.Content = "撤回失败"
+		} else {
+			data.Content = "消息已撤回"
+			data.IsRecalled = 1
+		}
 	}
 
 	jsonStrServeMsg := msg{


### PR DESCRIPTION
## Summary
- add backend and frontend changes for message recall support
- generated during dogfooding of Kimi K2.5
- kept as reviewable evidence for the evaluation run

## Session
- Session ID: .2367719388755610:6fcbc85b3c214a5c60814cdfec3a684e_69da3686c023ffbbf14faf8e.69da36acc023ffbbf14faf92.69da36aca5d42e5065010aa5:Trae CN.T(4/11/2026, 7:55:24 PM)
- Interaction rounds: 3
- Model: Kimi K2.5

## Evaluation summary
- Suggested overall satisfaction: 3/5
- Problem types: 代码 Bug, 指令遵循失败
- Fix cost: Medium

## Verified issues
- recall flow is mostly implemented and works better than the Doubao result
- however, after recall succeeds, the corresponding UI still does not update immediately in-place
- the recalled state becomes visible reliably only after refreshing the page
- this means the real-time recall UI path is still incomplete

## Note
- this PR is for dogfooding traceability and review
- it is not a claim that the feature is production-ready or ready to merge
- evaluation note: /Users/alfwong/codes/ai-coding/dogfooding/Kimi 2.5 - Go聊天室消息撤回功能评估.md